### PR TITLE
✨ [FEATURE] 뉴스 도메인 작업 내용 저장 (#3) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // JSOUP for crawling: https://mvnrepository.com/artifact/org.jsoup/jsoup
+    implementation group: 'org.jsoup', name: 'jsoup', version: '1.17.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
@@ -1,5 +1,6 @@
 package com.example.news_snap.domain.news.controller;
 
+import com.example.news_snap.domain.news.dto.NewsResponseDto;
 import com.example.news_snap.domain.news.service.NewsService;
 import com.example.news_snap.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/news")
@@ -19,7 +22,7 @@ public class NewsController {
 
     @Operation(summary = "헤드라인 뉴스 목록 조회", description = "Naver 경제 헤드라인 뉴스를 모두(10개) 조회합니다.")
     @GetMapping("/head-line")
-    public ApiResponse<?> getHeadLineNews() {
+    public ApiResponse<List<NewsResponseDto>> getHeadLineNews() {
         return ApiResponse.onSuccess(newsService.getHeadLineNews());
     }
 }

--- a/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
@@ -1,0 +1,25 @@
+package com.example.news_snap.domain.news.controller;
+
+import com.example.news_snap.domain.news.service.NewsService;
+import com.example.news_snap.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/news")
+@RequiredArgsConstructor
+@Tag(name = "News API")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @Operation(summary = "헤드라인 뉴스 목록 조회", description = "Naver 경제 헤드라인 뉴스를 모두(10개) 조회합니다.")
+    @GetMapping()
+    public ApiResponse<?> getHeadLineNews() {
+        return ApiResponse.onSuccess(newsService.getHeadLineNews());
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
@@ -18,7 +18,7 @@ public class NewsController {
     private final NewsService newsService;
 
     @Operation(summary = "헤드라인 뉴스 목록 조회", description = "Naver 경제 헤드라인 뉴스를 모두(10개) 조회합니다.")
-    @GetMapping()
+    @GetMapping("/head-line")
     public ApiResponse<?> getHeadLineNews() {
         return ApiResponse.onSuccess(newsService.getHeadLineNews());
     }

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.news_snap.domain.news.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NewsResponseDto(
+        String title, // 기사 제목
+        String imageURL, // 이미지 URL
+        String newsURL, // 뉴스 URL
+        String publisher, // 출판사
+//        String replyCnt, // 댓글 수
+        String relatedNewsCnt, // 관련 뉴스 수
+        String relatedURL // 관련 뉴스 URL
+) {
+}

--- a/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
+++ b/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
@@ -1,0 +1,55 @@
+package com.example.news_snap.domain.news.service;
+
+import com.example.news_snap.domain.news.dto.NewsResponseDto;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class NewsService {
+    private final String NAVER_NEWS_URL = "https://news.naver.com";
+    private final String ECONOMIC_NEWS_URL = NAVER_NEWS_URL + "/section/101"; //네이버 경제 뉴스 URL
+    private final String HEADLINE_CLASS = ".sa_item._SECTION_HEADLINE";
+
+    public List<NewsResponseDto> getHeadLineNews() {
+
+        List<NewsResponseDto> newsList = new ArrayList<>();
+
+        try {
+            Document document = Jsoup.connect(ECONOMIC_NEWS_URL).get();
+            Elements headLineList = document.select(HEADLINE_CLASS);
+
+            for (Element e : headLineList) {
+                String imageURL = e.select(".sa_thumb_inner").select("img").attr("data-src");
+                String newsURL = e.select(".sa_text").select("a").attr("href");
+                String title = e.select(".sa_text").select(".sa_text_strong").text();
+                String publisher = e.select(".sa_text_press").text();
+//                String replyCnt = e.select(".sa_text_info_left").select(".sa_text_cmt_COMMENT_COUNT_LIST").text();
+                String relatedURL = e.select(".sa_text_info_right > a").attr("href");
+                String relatedNewsCnt = e.select(".sa_text_info_right").select(".sa_text_cluster_num").text();
+
+                NewsResponseDto news = NewsResponseDto.builder()
+                        .imageURL(imageURL)
+                        .newsURL(newsURL)
+                        .title(title)
+                        .publisher(publisher)
+//                        .replyCnt(replyCnt)
+                        .relatedURL(NAVER_NEWS_URL + relatedURL)
+                        .relatedNewsCnt(relatedNewsCnt)
+                        .build();
+
+                newsList.add(news);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return newsList;
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
#3

## 📌 개요
- Controlle, Service 레이어 추가(네이버 헤드라인 뉴스 크롤링 API 구현)

## ✔️ Test
-
![image](https://github.com/user-attachments/assets/31188c44-6c9a-44c4-b931-4db690820f07)

단순히 [네이버 경제 뉴스 헤드라인] 뉴스 10개(고정) 크롤링 하는 API입니다.
REQ. : ❌