### PR TITLE
:sparkles: [FEATURE] 뉴스 키워드 검색 기능 구현 (#3)

### DIFF
--- a/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
@@ -1,6 +1,7 @@
 package com.example.news_snap.domain.news.controller;
 
 import com.example.news_snap.domain.news.dto.NewsResponseDto;
+import com.example.news_snap.domain.news.dto.NewsSearchOptions;
 import com.example.news_snap.domain.news.service.NewsService;
 import com.example.news_snap.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,5 +25,13 @@ public class NewsController {
     @GetMapping("/head-line")
     public ApiResponse<List<NewsResponseDto>> getHeadLineNews() {
         return ApiResponse.onSuccess(newsService.getHeadLineNews());
+    }
+
+    @Operation(summary = "뉴스 키워드 조회", description = "네이버 뉴스를 키워드로 검색합니다.")
+    @GetMapping()
+    public ApiResponse<?> searchNews(
+            NewsSearchOptions searchOptions
+    ) {
+        return ApiResponse.onSuccess(newsService.searchNews(searchOptions));
     }
 }

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsApiResponseDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsApiResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.news_snap.domain.news.dto;
+
+import com.example.news_snap.global.util.JsoupCrawling;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record NewsApiResponseDto(
+        List<NewsSummaryDto> items
+) {
+
+    // 네이버 뉴스 API로 조회한 Items의 네이버 뉴스만 필터링
+    public List<NewsSummaryDto> getOnlyNaverNews() {
+        return items.stream()
+                .filter(item -> item.link().startsWith("https://n.news")) // HTML구조가 상이하여, 네이버 뉴스만
+                .collect(Collectors.toList());
+    }
+
+    // 네이버 뉴스 링크로 접속하여 최종적으로 반환해줄 Dto 필드 크롤링하여 할당
+    public List<NewsResponseDto> getNewsResponseDto() {
+        return getOnlyNaverNews().stream()
+                .map(item -> item.toNewsResponseDto(new JsoupCrawling()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsResponseDto.java
@@ -7,9 +7,9 @@ public record NewsResponseDto(
         String title, // 기사 제목
         String imageURL, // 이미지 URL
         String newsURL, // 뉴스 URL
-        String publisher, // 출판사
+        String publisher // 출판사
 //        String replyCnt, // 댓글 수
-        String relatedNewsCnt, // 관련 뉴스 수
-        String relatedURL // 관련 뉴스 URL
+//        String relatedNewsCnt, // 관련 뉴스 수
+//        String relatedURL // 관련 뉴스 URL
 ) {
 }

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsSearchOptions.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsSearchOptions.java
@@ -1,0 +1,18 @@
+package com.example.news_snap.domain.news.dto;
+
+import lombok.Data;
+
+@Data
+public class NewsSearchOptions {
+
+    private String query; // 검색어. UTF-8로 인코딩되어야 합니다.
+    private Integer display; // 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
+    private Integer start; // 검색 시작 위치(기본값: 1, 최댓값: 1000)
+
+    /*
+    검색 결과 정렬 방법
+        - sim: 정확도순으로 내림차순 정렬(기본값)
+        - date: 날짜순으로 내림차순 정렬
+     */
+    private String sort;
+}

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsSummaryDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsSummaryDto.java
@@ -1,0 +1,37 @@
+package com.example.news_snap.domain.news.dto;
+
+import com.example.news_snap.global.util.JsoupCrawling;
+import org.jsoup.select.Elements;
+
+import java.util.Optional;
+
+// 네이버 뉴스 API response items 중, 필요한 데이터
+public record NewsSummaryDto(
+        String title,
+        String link,
+        String description
+) {
+
+    // 2차적으로 최종 반환될 추가 필드(이미지, 출판사) 크롤링하여 Building
+    public NewsResponseDto toNewsResponseDto(JsoupCrawling jsoupCrawling) {
+        String imgQuery = "#contents img";
+        String publisherQuery = ".media_end_head.go_trans img";
+        Optional<Elements> jsoupElementsIMG = jsoupCrawling.getJsoupElements(link, imgQuery);
+        Optional<Elements> jsoupElementsPUB = jsoupCrawling.getJsoupElements(link, publisherQuery);
+
+        if (jsoupElementsIMG.isPresent() || jsoupElementsPUB.isPresent()) {
+            return NewsResponseDto.builder()
+                    .title(title)
+                    .newsURL(link)
+                    .imageURL(jsoupElementsIMG.get().attr("data-src")) // +
+                    .publisher(jsoupElementsPUB.get().attr("title")) // +
+                    .build();
+        }
+
+        // 이미지 혹은 출판사 없을 시, 그대로 Building 하여 반환
+        return NewsResponseDto.builder()
+                .title(title)
+                .newsURL(link)
+                .build();
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/repository/NewsApiResponseRepository.java
+++ b/src/main/java/com/example/news_snap/domain/news/repository/NewsApiResponseRepository.java
@@ -1,0 +1,52 @@
+package com.example.news_snap.domain.news.repository;
+
+import com.example.news_snap.domain.news.dto.NewsApiResponseDto;
+import com.example.news_snap.domain.news.dto.NewsSearchOptions;
+import com.example.news_snap.global.common.code.status.ErrorStatus;
+import com.example.news_snap.global.common.exception.handler.NewsHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+@Repository
+public class NewsApiResponseRepository {
+
+    @Value("${X-Naver-Client-Id}")
+    private String newsApiClient;
+    @Value("${X-Naver-Client-Secret}")
+    private String newsApiKey;
+
+    // 네이버 뉴스 API로 뉴스 items를 검색해 가져오는 메서드
+    public Optional<NewsApiResponseDto> getNewsApiResponseDto(NewsSearchOptions options) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = getNaverApiRequestHeaders();
+
+        String url = "https://openapi.naver.com/v1/search/news.json?query=" + options.getQuery()
+                + "&display=" + options.getDisplay()
+                + "&start=" + options.getStart()
+                + "&sort=" + options.getSort();
+        ResponseEntity<NewsApiResponseDto> newsApiResponseDtoEntity = restTemplate.exchange(url, HttpMethod.GET,
+                new HttpEntity<>(headers), NewsApiResponseDto.class);
+
+        if (newsApiResponseDtoEntity.getStatusCode().is2xxSuccessful()) {
+            return Optional.ofNullable(newsApiResponseDtoEntity.getBody());
+        }
+
+        // 네이버 뉴스 API가 정상적으로 호출이 안될 시 예외처리
+        throw new NewsHandler(ErrorStatus._UNAVAILABLE_NEWS_API);
+    }
+
+    // 네이버 앱 ClientID 및 Secret key Header 할당하는 코드
+    private HttpHeaders getNaverApiRequestHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", newsApiClient);
+        headers.set("X-Naver-Client-Secret", newsApiKey);
+        return headers;
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
+++ b/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
@@ -1,21 +1,40 @@
 package com.example.news_snap.domain.news.service;
 
+import com.example.news_snap.domain.news.dto.NewsApiResponseDto;
 import com.example.news_snap.domain.news.dto.NewsResponseDto;
+import com.example.news_snap.domain.news.dto.NewsSearchOptions;
+import com.example.news_snap.domain.news.repository.NewsApiResponseRepository;
+import com.example.news_snap.global.common.code.status.ErrorStatus;
+import com.example.news_snap.global.common.exception.handler.NewsHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class NewsService {
     private final String NAVER_NEWS_URL = "https://news.naver.com";
     private final String ECONOMIC_NEWS_URL = NAVER_NEWS_URL + "/section/101"; //네이버 경제 뉴스 URL
     private final String HEADLINE_CLASS = ".sa_item._SECTION_HEADLINE";
+
+    private final NewsApiResponseRepository newsApiResponseRepository;
 
     public List<NewsResponseDto> getHeadLineNews() {
 
@@ -31,8 +50,8 @@ public class NewsService {
                 String title = e.select(".sa_text").select(".sa_text_strong").text();
                 String publisher = e.select(".sa_text_press").text();
 //                String replyCnt = e.select(".sa_text_info_left").select(".sa_text_cmt_COMMENT_COUNT_LIST").text();
-                String relatedURL = e.select(".sa_text_info_right > a").attr("href");
-                String relatedNewsCnt = e.select(".sa_text_info_right").select(".sa_text_cluster_num").text();
+//                String relatedURL = e.select(".sa_text_info_right > a").attr("href");
+//                String relatedNewsCnt = e.select(".sa_text_info_right").select(".sa_text_cluster_num").text();
 
                 NewsResponseDto news = NewsResponseDto.builder()
                         .imageURL(imageURL)
@@ -40,8 +59,8 @@ public class NewsService {
                         .title(title)
                         .publisher(publisher)
 //                        .replyCnt(replyCnt)
-                        .relatedURL(NAVER_NEWS_URL + relatedURL)
-                        .relatedNewsCnt(relatedNewsCnt)
+//                        .relatedURL(NAVER_NEWS_URL + relatedURL)
+//                        .relatedNewsCnt(relatedNewsCnt)
                         .build();
 
                 newsList.add(news);
@@ -52,4 +71,12 @@ public class NewsService {
 
         return newsList;
     }
+
+    public List<NewsResponseDto> searchNews(NewsSearchOptions options) {
+        NewsApiResponseDto newsApiResponseDto = newsApiResponseRepository.getNewsApiResponseDto(options)
+                .orElseThrow(() -> new NewsHandler(ErrorStatus._NOT_FOUND_NEWS));
+
+        return newsApiResponseDto.getNewsResponseDto();
+    }
+
 }

--- a/src/main/java/com/example/news_snap/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/news_snap/global/common/code/status/ErrorStatus.java
@@ -17,7 +17,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // User 에러
-    _NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER400", "사용자가 존재하지 않습니다.");
+    _NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER400", "사용자가 존재하지 않습니다."),
+
+    // News API 에러
+    _NOT_FOUND_NEWS(HttpStatus.NOT_FOUND, "NEWS400", "검색된 뉴스가 존재하지 않습니다."),
+    _UNAVAILABLE_NEWS_API(HttpStatus.SERVICE_UNAVAILABLE, "NEWS503", "Naver API 미작동, 관리자에게 문의 바랍니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/news_snap/global/common/exception/handler/NewsHandler.java
+++ b/src/main/java/com/example/news_snap/global/common/exception/handler/NewsHandler.java
@@ -1,0 +1,10 @@
+package com.example.news_snap.global.common.exception.handler;
+
+import com.example.news_snap.global.common.code.BaseErrorCode;
+import com.example.news_snap.global.common.exception.GeneralException;
+
+public class NewsHandler extends GeneralException {
+    public NewsHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/news_snap/global/util/JsoupCrawling.java
+++ b/src/main/java/com/example/news_snap/global/util/JsoupCrawling.java
@@ -1,0 +1,25 @@
+package com.example.news_snap.global.util;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class JsoupCrawling {
+
+    public Connection getConnection(String url) {
+        return Jsoup.connect(url);
+    }
+
+    public Optional<Elements> getJsoupElements(String url, String query) {
+
+        Connection conn = getConnection(url);
+        try {
+            return Optional.of(conn.get().select(query));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
- Controller, Service, repository 레이어 추가
- NewsResponseDto 반환 필드 수정(댓글수, 관련뉴스 수 삭제)
- JsoupCrawling 유틸 클래스 추가
- 

## ❗️ 관련 이슈 링크
# #3 

## 📌 개요
-  키워드로 뉴스를 검색합니다.

[첨언]: 
- 검색의 전체적인 흐름은 (1)Naver Search API ->  (2)크롤링(for 이미지, 출판사) 을 통해 이루어집니다. 따라서, display 파라미터를 50으로 두어도 (1)에서 50개의 뉴스(네이버뉴스 + 네이버에 게재되지 않은 뉴스)를 조회하고 그 중에서 n.news.naver.com으로 시작하는 네이버 뉴스만 크롤링해오기에 결과 수는 50보다 작거나 같습니다. (거의 무조건 작습니다..)
- 해당 API는 Naver Search API를 사용하므로,
.yml 파일에  아래 이미지처럼 clientID, secret key 등록 필요
![image](https://github.com/user-attachments/assets/e4980e55-6c67-4151-b7e2-e78d3e65a560)


## ✔️ Test
-
![image](https://github.com/user-attachments/assets/fb39fc8f-50c0-4ebe-945d-244b58651057)

**REQ:**
query : 검색어
display : 한 번에 표시할 검색 결과 개수(기본값:10, 최댓값:100)
start : 검색 시작 위치(기본값:1, 최댓값: 1000)
sort : 검색 결과 정렬 방법
    - sim : 정확도순으로 내림차순 정렬(기본값)
    - date : 날짜순으로 내림차순 정렬


ex. request param {
  "query": "AI",
  "display": 50,
  "start": 1,
  "sort": "date"
}
