### PR TITLE
✨ [FEATURE]증권 인기 검색어 조회 기능 구현 (#18)

### DIFF
--- a/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
+++ b/src/main/java/com/example/news_snap/domain/news/controller/NewsController.java
@@ -34,4 +34,10 @@ public class NewsController {
     ) {
         return ApiResponse.onSuccess(newsService.searchNews(searchOptions));
     }
+
+    @Operation(summary = "인기 검색어 조회", description = "네이버 증권의 인기 검색 키워드 top5를 조회합니다.")
+    @GetMapping("/popular-keywords")
+    public ApiResponse<?> getPopularKeywords() {
+        return ApiResponse.onSuccess(newsService.getPopularStocks());
+    }
 }

--- a/src/main/java/com/example/news_snap/domain/news/dto/NewsApiResponseDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/NewsApiResponseDto.java
@@ -18,6 +18,7 @@ public record NewsApiResponseDto(
 
     // 네이버 뉴스 링크로 접속하여 최종적으로 반환해줄 Dto 필드 크롤링하여 할당
     public List<NewsResponseDto> getNewsResponseDto() {
+
         return getOnlyNaverNews().stream()
                 .map(item -> item.toNewsResponseDto(new JsoupCrawling()))
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/news_snap/domain/news/dto/PopularStockDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/PopularStockDto.java
@@ -1,0 +1,9 @@
+package com.example.news_snap.domain.news.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PopularStockDto(
+        String stock,
+        Integer rank
+) {}

--- a/src/main/java/com/example/news_snap/domain/news/dto/PopularStockResponseDto.java
+++ b/src/main/java/com/example/news_snap/domain/news/dto/PopularStockResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.news_snap.domain.news.dto;
+
+import lombok.Builder;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record PopularStockResponseDto(
+        List<PopularStockDto> popularStocks
+) {
+
+    public PopularStockResponseDto sortByRank() {
+        List<PopularStockDto> collect = popularStocks.stream()
+                .sorted(Comparator.comparingInt(PopularStockDto::rank).reversed())
+                .collect(Collectors.toList());
+
+        return new PopularStockResponseDto(collect);
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/repository/CrawlingRepository.java
+++ b/src/main/java/com/example/news_snap/domain/news/repository/CrawlingRepository.java
@@ -1,0 +1,40 @@
+package com.example.news_snap.domain.news.repository;
+
+import com.example.news_snap.domain.news.dto.PopularStockDto;
+import com.example.news_snap.domain.news.dto.PopularStockResponseDto;
+import com.example.news_snap.global.util.JsoupCrawling;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CrawlingRepository {
+
+    private final JsoupCrawling jsoupCrawling;
+
+    public PopularStockResponseDto getPopularStockResponseDto() {
+
+        final String NAVER_PAY_FINANCE_URL = "https://finance.naver.com/";
+        String query = ".aside_area.aside_popular table tbody tr"; // 인기검색어 컴포넌트
+
+        List<PopularStockDto> stockDtoList = new ArrayList<>();
+
+        jsoupCrawling.getJsoupElements(NAVER_PAY_FINANCE_URL, query).get().stream()
+                .forEach(element ->
+                        {
+                            PopularStockDto build = PopularStockDto.builder()
+                                    .stock(element.select("th").text().substring(2))
+                                    .rank(Integer.parseInt(element.select("th em").text().substring(0, 1)))
+                                    .build();
+                            stockDtoList.add(build);
+                        }
+                );
+
+        return new PopularStockResponseDto(stockDtoList);
+    }
+}

--- a/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
+++ b/src/main/java/com/example/news_snap/domain/news/service/NewsService.java
@@ -3,13 +3,11 @@ package com.example.news_snap.domain.news.service;
 import com.example.news_snap.domain.news.dto.NewsApiResponseDto;
 import com.example.news_snap.domain.news.dto.NewsResponseDto;
 import com.example.news_snap.domain.news.dto.NewsSearchOptions;
+import com.example.news_snap.domain.news.dto.PopularStockResponseDto;
+import com.example.news_snap.domain.news.repository.CrawlingRepository;
 import com.example.news_snap.domain.news.repository.NewsApiResponseRepository;
 import com.example.news_snap.global.common.code.status.ErrorStatus;
 import com.example.news_snap.global.common.exception.handler.NewsHandler;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -18,14 +16,8 @@ import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +27,7 @@ public class NewsService {
     private final String HEADLINE_CLASS = ".sa_item._SECTION_HEADLINE";
 
     private final NewsApiResponseRepository newsApiResponseRepository;
+    private final CrawlingRepository crawlingRepository;
 
     public List<NewsResponseDto> getHeadLineNews() {
 
@@ -79,4 +72,9 @@ public class NewsService {
         return newsApiResponseDto.getNewsResponseDto();
     }
 
+    public PopularStockResponseDto getPopularStocks() {
+        PopularStockResponseDto popularStockResponseDto = crawlingRepository.getPopularStockResponseDto();
+
+        return popularStockResponseDto.sortByRank();
+    }
 }

--- a/src/main/java/com/example/news_snap/global/util/JsoupCrawling.java
+++ b/src/main/java/com/example/news_snap/global/util/JsoupCrawling.java
@@ -3,10 +3,12 @@ package com.example.news_snap.global.util;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Optional;
 
+@Component
 public class JsoupCrawling {
 
     public Connection getConnection(String url) {


### PR DESCRIPTION
- 크롤링을 위한 CrawlingRepository
- Controller, Service 레이어 구현

## ❗️ 관련 이슈 링크
# #18

## 📌 개요
- 네이버 > 증권 > 인기검색어 내용(stock name , rank)을 크롤링(Jsoup)하여 조회합니다.
(반드시 5개만 조회됩니다.)
## ✔️ Test
-
![image](https://github.com/user-attachments/assets/5f7a02df-3e63-4149-ac77-8e0d26bb764b)
